### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ General Words
 .. image:: https://travis-ci.org/petrilli/generalwords.png?branch=master
         :target: https://travis-ci.org/petrilli/generalwords
 
-.. image:: https://pypip.in/py_versions/generalwords/badge.png
+.. image:: https://img.shields.io/pypi/pyversions/generalwords.svg
     :target: https://pypi.python.org/pypi/generalwords/
     :alt: Supported Python versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20generalwords))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `generalwords`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.